### PR TITLE
ignore-pycharm-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 src/__pycache__
 src/vault-scanner.log
+.idea
+/venv*


### PR DESCRIPTION
#### Changes this pull request makes :
As i was setting the development environment I noticed that we are not ignoring `.idea` folder generated because of PyCharm IDE and `venv` folder.
Thanks
#### Checklist :

  - [x] My branch is up-to-date with the upstream master branch.
  - [ ] I have added the relevant documentation.
  - [ ] I have fully tested the changes locally.

#### Development environment

    OS: x
    Python Version: 3.6.7

